### PR TITLE
Update example7.ttl

### DIFF
--- a/Examples/lime/example7.ttl
+++ b/Examples/lime/example7.ttl
@@ -1,5 +1,5 @@
 @prefix : <> .
-@prefix dct: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix lime: <http://www.w3.org/ns/lemon/lime#> .
 @prefix ontolex: <http://www.w3.org/ns/lemon/ontolex#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .


### PR DESCRIPTION
fixed namespace for dct prefix (now using dc terms namespace and not elements/1.1)